### PR TITLE
fix: Pin python version to 3.12 instead of using latest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM continuumio/miniconda3:latest
 
+RUN conda create -n conda-env python=3.12
+RUN conda activate conda-env
 RUN conda install -y anaconda-client conda-build conda-verify numpy
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Attempt to fix the following release failure:

https://github.com/h2oai/wave/actions/runs/15130941065/job/42531689378

Not sure if the env will be properly activated within entrypoint script as well. Will see.